### PR TITLE
Fix x-ms-date format issue for non-english locales

### DIFF
--- a/src/com/microsoft/azure/documentdb/GatewayProxy.java
+++ b/src/com/microsoft/azure/documentdb/GatewayProxy.java
@@ -13,6 +13,7 @@ import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
@@ -169,7 +170,7 @@ final class GatewayProxy {
         if (this.masterKey != null) {
             final Date currentTime = new Date();
             final SimpleDateFormat sdf =
-                new SimpleDateFormat("E, dd MMM yyyy HH:mm:ss z");
+                new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US);
             sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
             String xDate = sdf.format(currentTime);
 


### PR DESCRIPTION
Computers running on non-English locales may run in to a "com.microsoft.azure.documentdb.DocumentClientException: The input date header is invalid format. Please pass in RFC 1123 style date format." in which the x-ms-date fails server validation.

Details: https://social.msdn.microsoft.com/Forums/azure/en-US/de4ad792-6b58-42e7-803c-4c6f549094c0/documentdb-java-example-errors?forum=AzureDocumentDB

This fix is to use format the x-ms-date using Locale.US
