### PR TITLE
Bug fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.microsoft.azure</groupId>
   <artifactId>azure-documentdb</artifactId>
-  <version>0.9.3</version>
+  <version>0.9.4</version>
   <name>${project.groupId}:${project.artifactId}</name>
   <description>Java SDK for Microsoft Azure DocumentDB</description>
   <url>http://azure.microsoft.com/en-us/services/documentdb/</url>

--- a/src/com/microsoft/azure/documentdb/DocumentClientException.java
+++ b/src/com/microsoft/azure/documentdb/DocumentClientException.java
@@ -68,7 +68,7 @@ public class DocumentClientException extends Exception {
             String header = this.responseHeaders.get(
             HttpConstants.HttpHeaders.RETRY_AFTER_IN_MILLISECONDS);
 
-            if (!header.isEmpty()) {
+            if (header != null && !header.isEmpty()) {
                 long retryIntervalInMilliseconds = Long.valueOf(header);
                 return retryIntervalInMilliseconds;
             }

--- a/src/com/microsoft/azure/documentdb/HttpConstants.java
+++ b/src/com/microsoft/azure/documentdb/HttpConstants.java
@@ -153,7 +153,7 @@ class HttpConstants {
 
         public static String CURRENT_VERSION = "2014-08-21";
 
-        public static String USER_AGENT = "documentdb-java-sdk-0.9.3";
+        public static String USER_AGENT = "documentdb-java-sdk-0.9.4";
     }
     
     public static class StatusCodes {

--- a/src/com/microsoft/azure/documentdb/QueryIterable.java
+++ b/src/com/microsoft/azure/documentdb/QueryIterable.java
@@ -190,6 +190,8 @@ public class QueryIterable<T extends Resource> implements Iterable<T> {
             this.continuation = this.responseHeaders.get(HttpConstants.HttpHeaders.CONTINUATION);
 
             fetchedItems = response.getQueryResponse(this.classT);
+            this.items.clear();
+            this.currentIndex = 0;
             this.items.addAll(fetchedItems);
 
             if (fetchedItems != null && fetchedItems.size() > 0) {


### PR DESCRIPTION
QueryIterable shouldn't cache all documents and should only cache one page, this was causing memory leakage.
RetryAfter header null check as if the retry after is 0 the header would be null and would cause an exception Pumping up the version to 0.9.4