### PR TITLE
Fixes typos and bugs.

### DIFF
--- a/src/com/microsoft/azure/documentdb/ConnectionPolicy.java
+++ b/src/com/microsoft/azure/documentdb/ConnectionPolicy.java
@@ -73,7 +73,7 @@ public final class ConnectionPolicy {
     private ConnectionMode connectionMode;
 
     /**
-     * Gets the connection mode used in the client. Currently only Gateway in supported.
+     * Gets the connection mode used in the client. Currently only Gateway is supported.
      * 
      * @return the connection mode.
      */
@@ -82,7 +82,7 @@ public final class ConnectionPolicy {
     }
 
     /**
-     * Sets the connection mode used in the client. Currently only Gateway in supported.
+     * Sets the connection mode used in the client. Currently only Gateway is supported.
      * 
      * @param connectionMode the connection mode.
      */

--- a/src/com/microsoft/azure/documentdb/DocumentClient.java
+++ b/src/com/microsoft/azure/documentdb/DocumentClient.java
@@ -129,7 +129,7 @@ public final class DocumentClient {
         this.desiredConsistencyLevel = desiredConsistencyLevel;
 
         UserAgentContainer userAgentContainer = new UserAgentContainer();
-        String userAgentSuffix = connectionPolicy.getUserAgentSuffix();
+        String userAgentSuffix = this.connectionPolicy.getUserAgentSuffix();
         if(userAgentSuffix != null && userAgentSuffix.length() > 0) {
             userAgentContainer.setSuffix(userAgentSuffix);
         }

--- a/src/com/microsoft/azure/documentdb/DocumentServiceRequest.java
+++ b/src/com/microsoft/azure/documentdb/DocumentServiceRequest.java
@@ -5,7 +5,7 @@
 package com.microsoft.azure.documentdb;
 
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -98,12 +98,8 @@ final class DocumentServiceRequest {
                                                 String relativePath,
                                                 Resource resource,
                                                 Map<String, String> headers) {
-        try {
-            HttpEntity body = new StringEntity(resource.toString());
-            return new DocumentServiceRequest(resourceType, relativePath, body, headers);
-        } catch (UnsupportedEncodingException e) {
-            throw new IllegalArgumentException("Failed to get HttpEntity from resource.", e);
-        }
+        HttpEntity body = new StringEntity(resource.toString(), StandardCharsets.UTF_8);
+        return new DocumentServiceRequest(resourceType, relativePath, body, headers);
     }
 
     /**
@@ -119,12 +115,8 @@ final class DocumentServiceRequest {
                                                 String relativePath,
                                                 String query,
                                                 Map<String, String> headers) {
-        try {
-            HttpEntity body = new StringEntity(query);
-            return new DocumentServiceRequest(resourceType, relativePath, body, headers);
-        } catch (UnsupportedEncodingException e) {
-            throw new IllegalArgumentException("Failed to get HttpEntity from resource.", e);
-        }
+        HttpEntity body = new StringEntity(query, StandardCharsets.UTF_8);
+        return new DocumentServiceRequest(resourceType, relativePath, body, headers);
     }
 
     /**
@@ -160,12 +152,8 @@ final class DocumentServiceRequest {
                 break;
         }
 
-        try {
-            HttpEntity body = new StringEntity(queryText);
-            return new DocumentServiceRequest(resourceType, relativePath, body, headers);
-        } catch (UnsupportedEncodingException e) {
-            throw new IllegalArgumentException("Failed to get HttpEntity from resource.", e);
-        }
+        HttpEntity body = new StringEntity(queryText, StandardCharsets.UTF_8);
+        return new DocumentServiceRequest(resourceType, relativePath, body, headers);
     }
 
     /**

--- a/src/com/microsoft/azure/documentdb/FeedResponse.java
+++ b/src/com/microsoft/azure/documentdb/FeedResponse.java
@@ -95,7 +95,7 @@ public final class FeedResponse<T extends Resource> {
     /**
      * Max Quota.
      * 
-     * @return the document size quota.
+     * @return the collection size quota.
      */
     public long getCollectionSizeQuota() {
         return this.getMaxQuotaHeader(Constants.Quota.COLLECTION_SIZE);
@@ -104,7 +104,7 @@ public final class FeedResponse<T extends Resource> {
     /**
      * Current Usage.
      *  
-     * @return the current document size usage.
+     * @return the current collection size usage.
      */
     public long getCollectionSizeUsage() {
         return this.getCurrentQuotaHeader(Constants.Quota.COLLECTION_SIZE);

--- a/src/com/microsoft/azure/documentdb/test/GatewayTests.java
+++ b/src/com/microsoft/azure/documentdb/test/GatewayTests.java
@@ -541,7 +541,7 @@ public final class GatewayTests {
         Document documentDefinition = new Document(
                 "{" +
                 "  'name': 'sample document'," +
-                "  'foo': 'bar'," +
+                "  'foo': 'bar 你好'," +  // foo contains some UTF-8 characters.
                 "  'key': 'value'" +
                 "}");
 
@@ -559,6 +559,8 @@ public final class GatewayTests {
                                                   null,
                                                   false).getResource();
         Assert.assertEquals(documentDefinition.getString("name"), document.getString("name"));
+        Assert.assertEquals(documentDefinition.getString("foo"), document.getString("foo"));
+        Assert.assertEquals(documentDefinition.getString("bar"), document.getString("bar"));
         Assert.assertNotNull(document.getId());
 
         // Read documents after creation.


### PR DESCRIPTION
Resource content should always be encoded as UTF-8.