### PR TITLE
Query iterator remove throws UnsupportedOperation

### DIFF
--- a/src/com/microsoft/azure/documentdb/QueryIterable.java
+++ b/src/com/microsoft/azure/documentdb/QueryIterable.java
@@ -117,14 +117,11 @@ public class QueryIterable<T extends Resource> implements Iterable<T> {
             }
 
             /**
-             * Removes the current value.
+             * Remove not supported.
              */
             @Override
             public void remove() {
-                if (!hasNext()) throw new NoSuchElementException();
-                if (currentIndex < items.size()) {
-                    items.remove(currentIndex);
-                }
+                throw new UnsupportedOperationException("remove");
             }
 
         };


### PR DESCRIPTION
Current implementaton is misleading, it remove from a temporary internal list, not from the collection. Simply not supporting the optional operation makes more sense.

Also, current implementation has a major bug. NoSuchElementException on no hasNext should have been IllegalStateException when next as not been called piror, and remove should be on currentIndex - 1.