### PR TITLE
Remove printStackTrace

### DIFF
--- a/src/com/microsoft/azure/documentdb/BackoffRetryUtility.java
+++ b/src/com/microsoft/azure/documentdb/BackoffRetryUtility.java
@@ -16,7 +16,6 @@ class BackoffRetryUtility {
             } catch (Exception e) {
                 boolean retry = retryPolicy.shouldRetry(e);
                 if (!retry) {
-                    e.printStackTrace();
                     throw new IllegalStateException("Exception not retriable", e);
                 }
 

--- a/src/com/microsoft/azure/documentdb/Document.java
+++ b/src/com/microsoft/azure/documentdb/Document.java
@@ -47,7 +47,6 @@ public class Document extends Resource {
             try {
                 return new Document (mapper.writeValueAsString(document));
             } catch (IOException e) {
-                e.printStackTrace();
                 throw new IllegalArgumentException("Can't serialize the object into the json string", e);
             }
         }

--- a/src/com/microsoft/azure/documentdb/DocumentClient.java
+++ b/src/com/microsoft/azure/documentdb/DocumentClient.java
@@ -2185,7 +2185,6 @@ public final class DocumentClient {
                 try {
                     stringArray[i] = mapper.writeValueAsString(object);
                 } catch (IOException e) {
-                    e.printStackTrace();
                     throw new IllegalArgumentException("Can't serialize the object into the json string", e);
                 }
             }

--- a/src/com/microsoft/azure/documentdb/DocumentServiceResponse.java
+++ b/src/com/microsoft/azure/documentdb/DocumentServiceResponse.java
@@ -161,7 +161,6 @@ final class DocumentServiceResponse implements AutoCloseable {
             try {
                 EntityUtils.consume(this.httpEntity);
             } catch (IOException e) {
-                e.printStackTrace();
                 throw new IllegalStateException(e);
             }
         }

--- a/src/com/microsoft/azure/documentdb/GatewayProxy.java
+++ b/src/com/microsoft/azure/documentdb/GatewayProxy.java
@@ -247,7 +247,6 @@ final class GatewayProxy {
                     body = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
                     EntityUtils.consume(response.getEntity());
                 } catch (ParseException | IOException e) {
-                    e.printStackTrace();
                     // body is empty.
                     throw new IllegalStateException("Failed to get content from the http response", e);
                 }

--- a/src/com/microsoft/azure/documentdb/JsonSerializable.java
+++ b/src/com/microsoft/azure/documentdb/JsonSerializable.java
@@ -163,7 +163,6 @@ class JsonSerializable {
             try {
                 this.propertyBag.put(propertyName, new JSONObject(mapper.writeValueAsString(value)));
             } catch (IOException e) {
-                e.printStackTrace();
                 throw new IllegalArgumentException("Can't serialize the object into the json string", e);
             }
         }
@@ -198,7 +197,6 @@ class JsonSerializable {
                     try {
                         targetArray.put(new JSONObject(mapper.writeValueAsString(childValue)));
                     } catch (IOException e) {
-                        e.printStackTrace();
                         throw new IllegalArgumentException("Can't serialize the object into the json string", e);
                     }
                 }
@@ -308,7 +306,6 @@ class JsonSerializable {
                 try {
                     return new ObjectMapper().readValue(jsonObj.toString(), c);
                 } catch (IOException e) {
-                    e.printStackTrace();
                     throw new IllegalStateException("Failed to get POJO.", e);
                 }
             }
@@ -376,7 +373,6 @@ class JsonSerializable {
                     try {
                         result.add(mapper.readValue(jsonObject.toString(), c));
                     } catch (IOException e) {
-                        e.printStackTrace();
                         throw new IllegalStateException("Failed to get POJO.", e);
                     }
                 }
@@ -451,7 +447,6 @@ class JsonSerializable {
             try {
                 return new ObjectMapper().readValue(this.toString(), c);
             } catch (IOException e) {
-                e.printStackTrace();
                 throw new IllegalStateException("Failed to get POJO.", e);
             }
         }


### PR DESCRIPTION
Please remove printStackTrace where re-throws Exception after.

Because printStackTrace's outputs to console is complicated.
At least, output to Logger is better.
