### PR TITLE
Fix improper @param name

### DIFF
--- a/src/com/microsoft/azure/documentdb/HashPartitionResolver.java
+++ b/src/com/microsoft/azure/documentdb/HashPartitionResolver.java
@@ -130,7 +130,7 @@ public class HashPartitionResolver implements PartitionResolver {
     /**
      * Resolves the collection for reading/querying the documents based on the partition key.
      * 
-     * @param document the document to be read/queried.
+     * @param partitionKey the partition Key to be read/queried.
      * 
      * @return collection Self link(s) or Name based link(s) which should handle the Read operation
      */


### PR DESCRIPTION
The @param name should be partitionKey rather than document. This causes javadocs to error out. (ditto to last one)