### PR TITLE
Fix Java SDK to not send extra request in CreateDocument

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.microsoft.azure</groupId>
   <artifactId>azure-documentdb</artifactId>
-  <version>1.8.0</version>
+  <version>1.8.1</version>
   <name>${project.groupId}:${project.artifactId}</name>
   <description>Java SDK for Microsoft Azure DocumentDB</description>
   <url>http://azure.microsoft.com/en-us/services/documentdb/</url>
@@ -164,7 +164,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/com/microsoft/azure/documentdb/HttpConstants.java
+++ b/src/com/microsoft/azure/documentdb/HttpConstants.java
@@ -169,7 +169,7 @@ class HttpConstants {
 
     public static class Versions {
         public static String CURRENT_VERSION = "2016-05-30";
-        public static String USER_AGENT = "documentdb-java-sdk-1.8.0";
+        public static String USER_AGENT = "documentdb-java-sdk-1.8.1";
     }
     
     public static class StatusCodes {

--- a/src/com/microsoft/azure/documentdb/InMemoryPartitionKeyDefinitionMap.java
+++ b/src/com/microsoft/azure/documentdb/InMemoryPartitionKeyDefinitionMap.java
@@ -77,6 +77,10 @@ final class InMemoryPartitionKeyDefinitionMap implements PartitionKeyDefinitionM
 		try {
 			DocumentCollection collection = this.documentClient.readCollection(collectionName, null).getResource();
 			keyDef = collection.getPartitionKey();
+            if (keyDef == null) {
+                // Use an empty PartitionKeyDefinition to indicate single partition collection
+                keyDef = new PartitionKeyDefinition();
+            }
 		} catch (DocumentClientException e) {
 			// Ignore document retrieval exception and let the server handle partition key missing error.
 		}


### PR DESCRIPTION
This change fixes 2 issues to not send extra request in CreateDocument:

          - The PartitionKeyDefinitionMap doesn't handle null partition key for single partition collection so the partition key definition is resolved in every requests. Added an empty PartitionKey instance to mark single partition collection and eliminate this resolution in subsequent requests.

          - For partitioned collection if the user specifies mismatched partition key value we will retry and eventually fail after a number of time (now it is 1). Added a check to not retry in this case.

cc: @shellygms